### PR TITLE
chore: add .idea/ to .gitignore to exclude IDE files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 build/bin
 node_modules
 frontend/dist
+
+.idea/


### PR DESCRIPTION
Add .idea/ directory to .gitignore to prevent committing IDE
configuration files. This keeps the repository clean and avoids
sharing personal development environment settings.